### PR TITLE
Add fixes for Crysis

### DIFF
--- a/protonfixes/gamefixes/17300.py
+++ b/protonfixes/gamefixes/17300.py
@@ -1,0 +1,15 @@
+""" Game fix for Crysis
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ Installs d3dcompiler_43, disables esync
+    """
+
+    # https://github.com/ValveSoftware/Proton/issues/178#issuecomment-422986182
+    util.protontricks('d3dcompiler_43')
+    
+    # https://github.com/ValveSoftware/Proton/issues/178#issuecomment-415201326
+    util.disable_esync()


### PR DESCRIPTION
Apply necessary fixes to get Crysis running, and using DX10.